### PR TITLE
fix: update frontend deployment to use official Vercel CLI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ jobs:
   deploy-frontend:
     runs-on: ubuntu-latest
     if: contains(github.event.head_commit.modified, 'frontend/') || contains(github.event.head_commit.modified, 'shared/') || github.event_name == 'workflow_dispatch'
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     
     steps:
       - name: Checkout code
@@ -25,25 +28,20 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
 
-      - name: Install dependencies
-        run: |
-          npm ci
-          cd frontend && npm ci
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
 
-      - name: Build shared package
-        run: cd shared && npm run build
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: ./frontend
 
-      - name: Build frontend
-        run: cd frontend && npm run build
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: ./frontend
 
-      - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          working-directory: ./frontend
-          vercel-args: '--prod'
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: ./frontend
 
   # Deploy Backend to Fly.io
   deploy-backend:


### PR DESCRIPTION
- Replace third-party vercel-action with official Vercel CLI commands
- Add VERCEL_ORG_ID and VERCEL_PROJECT_ID environment variables
- Use vercel pull, build, and deploy --prebuilt workflow
- Follow official Vercel GitHub Actions documentation