### PR TITLE
ci: configure GitHub Flow strategy for PR-based workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,15 @@
 name: CI/CD Pipeline
 
 on:
-  push:
-    branches: [ main, develop ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
+
+# This workflow runs on PRs to main for testing and validation
+# Does NOT deploy - deployment happens via deploy.yml after PR merge
 
 env:
   NODE_VERSION: '18'
-  PYTHON_VERSION: '3.9'
+  PYTHON_VERSION: '3.13'
 
 jobs:
   # Lint commit messages for conventional commits (required for release-please)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,12 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# This workflow only runs on pushes to main (via merged PRs)
+# Direct pushes to main should be blocked by branch protection rules
+
 env:
   NODE_VERSION: '18'
-  PYTHON_VERSION: '3.9'
+  PYTHON_VERSION: '3.13'
 
 jobs:
   # Deploy Frontend to Vercel

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: Pull Request Checks
 
 on:
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
 
 jobs:
   # Lint commit messages for conventional commits (required for release-please)


### PR DESCRIPTION
- Update deploy.yml to only run on pushes to main (production)
- Update ci.yml to only run on pull requests to main
- Update pr.yml to only trigger on PRs to main
- Update Python version to 3.13 across workflows
- Configure Vercel deployments for production environment
- Add comments explaining workflow triggers and purposes